### PR TITLE
CustomMultiSelectFix

### DIFF
--- a/mz_bokeh_package/custom_widgets/implementation_files/multiselect.ts
+++ b/mz_bokeh_package/custom_widgets/implementation_files/multiselect.ts
@@ -150,11 +150,10 @@ export class CustomMultiSelectView extends InputWidgetView {
   connect_signals(): void {
     super.connect_signals()
 
-    const {value, options, select_all, name, title, enabled} = this.model.properties
+    const {value, options, name, title, enabled} = this.model.properties
     this.on_change(value, () => this.update_value())
     this.on_change([name, title], () => this.render())
     this.on_change(enabled, () => this.enable_widget())
-    this.on_change(select_all, () => this.select_all(false))
     this.on_change(options, () => this.update_options())
   }
 


### PR DESCRIPTION
Steps to reproduce the bug:
1. Run the following dashboard:
```python
from bokeh.io import curdoc
from mz_bokeh_package.custom_widgets import CustomMultiSelect

ms = CustomMultiSelect(
    include_select_all=True,
    options=["1","2"],
)


def on_change(attr, old, new):
    print(ms.select_all)


ms.on_change("value", on_change)

curdoc().add_root(ms)

```
2. Select all the options and close the dropdown.
3. The callback of the `value` property prints `False` instead of `True`.