### PR TITLE
optional parameter for async_event_handler

### DIFF
--- a/mz_bokeh_package/utilities/bokeh_utilities.py
+++ b/mz_bokeh_package/utilities/bokeh_utilities.py
@@ -1,29 +1,50 @@
 from functools import partial
 import inspect
+from typing import Optional
 
 
 class BokehUtilities:
 
     @staticmethod
-    def async_event_handler(func):
-        """This function can be used as a decorator for callbacks in order to display a loading banner
-        while the callback is running.
+    def async_event_handler(_func=None, *, function_to_execute: Optional[str]=None):
+        """A decorator for event handlers to run them asynchronously and display the loading spinner while they run
+
+        This decorator will cause the decorated event handler to run asynchronously, the loading spinner
+        will be turned on while the event handler is running, and the function_to_execute will be called before the
+        event handler is executed with a True parameter and after with a False parameter.
+        The latter can be used, for example, to disable certain controls while the event handler is executing.
+
+        Params:
+            function_to_execute - the name of a method of the class that accepts a single boolean parameter. For example,
+                                  there could be a method `def _disable_controls(self, disable: bool), in which case the
+                                  string "_disable_controls" should be passed.
         """
 
-        def outer(self, *args, **kwargs):
-            self._state["is_loading"] = True
-            self._doc.add_next_tick_callback(partial(inner, func, self, *args, **kwargs))
+        def _async_event_handler(func):
 
-        def inner(f, self, *args, **kwargs):
-            f(self, *args, **kwargs)
-            self._state["is_loading"] = False
+            def outer(self, *args, **kwargs):
+                self._state["is_loading"] = True
+                if function_to_execute is not None:
+                    getattr(self, function_to_execute)(True)
+                self._doc.add_next_tick_callback(partial(inner, func, self, *args, **kwargs))
 
-        # create a version of outer that has the same signature as func (since that is expected by Bokeh)
-        func_signature = str(inspect.signature(func))
-        outer_with_signature_def = f"lambda {func_signature.lstrip('(').rstrip(')')}: outer{func_signature}"
-        outer_with_signature = eval(outer_with_signature_def, {'outer': outer})
+            def inner(f, self, *args, **kwargs):
+                f(self, *args, **kwargs)
+                if function_to_execute is not None:
+                    getattr(self, function_to_execute)(False)
+                self._state["is_loading"] = False
 
-        return outer_with_signature
+            # create a version of outer that has the same signature as func (since that is expected by Bokeh)
+            func_signature = str(inspect.signature(func))
+            outer_with_signature_def = f"lambda {func_signature.lstrip('(').rstrip(')')}: outer{func_signature}"
+            outer_with_signature = eval(outer_with_signature_def, {'outer': outer})
+
+            return outer_with_signature
+
+        if _func is None:
+            return _async_event_handler
+        else:
+            return _async_event_handler(_func)
 
     @staticmethod
     def silent_property_change(widget, property, value):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="mz_bokeh_package",
-    version="0.0.4",
+    version="0.0.5",
     packages=["mz_bokeh_package"],
     include_package_data=True,
 


### PR DESCRIPTION
In this PR, I added the option to pass an optional parameter 'function_to_execute' to the decorator async_event_handler. This parameter is the name (passed as a string) of a method that takes a single boolean parameter. This method will be executed with True before the event handler is executed, and with False at the end. This, for example, can be used to disable certain controls while the event handler runs, and enable them again in the end (something we do in the Histogram and Correlation and because of which we could not use the decorator until now).