### PR TITLE
Add an s to http if the host name contains 'api'

### DIFF
--- a/mz_bokeh_package/utilities/environment.py
+++ b/mz_bokeh_package/utilities/environment.py
@@ -37,18 +37,15 @@ class Environment:
         """
 
         env = cls.get_environment()
-        add_an_s = ""
 
         if env == 'staging':
-            host = 'staging.materials.zone:5000'
+            host = 'https://api-staging.materials.zone/v1beta1'
         elif env == 'production':
-            host = 'production.materials.zone:5000'
+            host = 'https://api.materials.zone/v1beta1'
         elif env == 'dev':
-            host = os.getenv('API_HOST', 'staging.materials.zone:5000')
-            if host.find('api') > -1:
-                add_an_s = "s"
+            host = os.getenv('API_HOST', 'https://api-staging.materials.zone/v1beta1')
 
-        return f"http{add_an_s}://{host}/{endpoint}"
+        return f"{host}/{endpoint}"
 
     @classmethod
     def get_error_page_url(cls) -> str:

--- a/mz_bokeh_package/utilities/environment.py
+++ b/mz_bokeh_package/utilities/environment.py
@@ -37,6 +37,7 @@ class Environment:
         """
 
         env = cls.get_environment()
+        add_an_s = ""
 
         if env == 'staging':
             host = 'staging.materials.zone:5000'
@@ -44,8 +45,10 @@ class Environment:
             host = 'production.materials.zone:5000'
         elif env == 'dev':
             host = os.getenv('API_HOST', 'staging.materials.zone:5000')
+            if host.find('api') > -1:
+                add_an_s = "s"
 
-        return f"http://{host}/{endpoint}"
+        return f"http{add_an_s}://{host}/{endpoint}"
 
     @classmethod
     def get_error_page_url(cls) -> str:

--- a/mz_bokeh_package/utilities/environment.py
+++ b/mz_bokeh_package/utilities/environment.py
@@ -27,7 +27,10 @@ class Environment:
 
     @classmethod
     def get_request_url(cls, endpoint: str) -> str:
-        """receives an endpoint of an API request and converts it to a request url based on the environment
+        """receives an endpoint of an API request and converts it to a request url based on the environment.
+        If the environment variable 'ENVIRONMENT' is set to 'dev' the environment variable 'API_HOST' should
+        be set to the desired url, including 'https://'. If 'API_HOST' is not set in the development environment,
+        the default staging url will be returned.
 
         Args:
             endpoint: the endpoint of the request

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="mz_bokeh_package",
-    version="0.4.0",
+    version="0.5.0",
     packages=["mz_bokeh_package"],
     include_package_data=True,
 

--- a/tests/unit/test_get_request_url.py
+++ b/tests/unit/test_get_request_url.py
@@ -1,0 +1,27 @@
+import os
+import pytest
+
+from typing import Callable, Optional
+
+from mz_bokeh_package.utilities import Environment
+
+staging_url = 'https://api-staging.materials.zone/v1beta1' + '/'
+production_url = 'https://api.materials.zone/v1beta1' + '/'
+custom_api_host_url = 'http://staging.materials.zone:5000' + '/'
+
+# The order of the tests is important. set_env_to_development_with_own_host sets the environment variable
+# API_HOST which is expected not to be set for the other test.
+test_parameters = [("staging", staging_url, None),
+                   ("production", production_url, None),
+                   ("dev", staging_url, None),
+                   ("dev", custom_api_host_url, custom_api_host_url[:-1])]
+
+
+@pytest.mark.parametrize('environment, expected_url, custom_api_host', test_parameters)
+def test_environment(environment: Callable, expected_url: str, custom_api_host: Optional[str]) -> None:
+    os.environ['ENVIRONMENT'] = environment
+    if custom_api_host is not None:
+        os.environ['API_HOST'] = custom_api_host
+
+    assert Environment.get_request_url("") == expected_url
+    assert Environment.get_request_url("test") == expected_url + "test"

--- a/tests/unit/test_get_request_url.py
+++ b/tests/unit/test_get_request_url.py
@@ -9,17 +9,19 @@ staging_url = 'https://api-staging.materials.zone/v1beta1' + '/'
 production_url = 'https://api.materials.zone/v1beta1' + '/'
 custom_api_host_url = 'http://staging.materials.zone:5000' + '/'
 
-# The order of the tests is important. set_env_to_development_with_own_host sets the environment variable
-# API_HOST which is expected not to be set for the other test.
 test_parameters = [("staging", staging_url, None),
                    ("production", production_url, None),
+                   ("dev", custom_api_host_url, custom_api_host_url[:-1]),
                    ("dev", staging_url, None),
-                   ("dev", custom_api_host_url, custom_api_host_url[:-1])]
+                   ]
 
 
 @pytest.mark.parametrize('environment, expected_url, custom_api_host', test_parameters)
 def test_environment(environment: Callable, expected_url: str, custom_api_host: Optional[str]) -> None:
     os.environ['ENVIRONMENT'] = environment
+
+    if 'API_HOST' in os.environ:
+        del os.environ['API_HOST']
     if custom_api_host is not None:
         os.environ['API_HOST'] = custom_api_host
 


### PR DESCRIPTION
As the http port is closed on api-staging.materials.zone and the https port is working on api.materials.zone, an s is added to the http if the requested url contains "api".