### PR TITLE
Remove italic from options for the axis label font style

### DIFF
--- a/mz_bokeh_package/components/plot_settings.py
+++ b/mz_bokeh_package/components/plot_settings.py
@@ -379,11 +379,11 @@ class PlotSettings:
 
     @_text_thickness.setter
     def _text_thickness(self, value: bool):
-        axis_label_style, major_label_style = ("bold", "bold") if value else ("italic", "normal")
-        self._plot.xaxis.major_label_text_font_style = major_label_style
-        self._plot.yaxis.major_label_text_font_style = major_label_style
-        self._plot.xaxis.axis_label_text_font_style = axis_label_style
-        self._plot.yaxis.axis_label_text_font_style = axis_label_style
+        label_style = "bold" if value else "normal"
+        self._plot.xaxis.major_label_text_font_style = label_style
+        self._plot.yaxis.major_label_text_font_style = label_style
+        self._plot.xaxis.axis_label_text_font_style = label_style
+        self._plot.yaxis.axis_label_text_font_style = label_style
 
     @property
     def _axes_thickness(self) -> bool:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="mz_bokeh_package",
-    version="0.6.2",
+    version="0.6.3",
     packages=["mz_bokeh_package"],
     include_package_data=True,
 


### PR DESCRIPTION
[Jira card MZC 1113](https://materialszone.atlassian.net/browse/MZC-1113)
The root of the font-styles seems to have been in the mz-bokeh-package not in the dashboards as speculated in the card. I hope it is ok to fix it here. Or does that possibly affect other packages, too?