### PR TITLE
Allow to fetch user credentials in dev environment w/o querying curdoc()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,10 @@
+Changes in MZ-Bokeh-Package
+===========================
+
+0.10.0
+******
+
+In the `dev` environment you can now get responses from `CurrentUser.get_api_key()` and
+`CurrentUser.get_user_key()` without starting a bokeh-server. For this to work, the respective 
+environment variables have to be set as usual, though. Their content can be meaningful or just a dummy, according
+to the requirements. Querying an undefined variable raises a `KeyError`. 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@ To install the latest version of this package in your current environment do:
 pip install git+https://github.com/materialscloud/mz-bokeh-package.git@master
 ```
 
-Or add to your `requirements.txt` file the following:
+Or add to your `requirements.txt`/`setup.py` file the following:
 ```
 git+https://github.com/materialscloud/mz-bokeh-package.git@master
 ```
+
+## Changes and Version Number
+With every PR merged into the `master` branch, please add a version tag to the latest commit
+and add a __short__ description of the changes to the file `CHANGES.md` (newer entries at the top).

--- a/mz_bokeh_package/utilities/auth.py
+++ b/mz_bokeh_package/utilities/auth.py
@@ -109,6 +109,10 @@ class CurrentUser:
         Returns:
             the api_key of the current user
         """
+        # in the development environment, allow overriding the api_key and user_key via env variables
+        if Environment.get_environment() == 'dev':
+            api_key = os.getenv('API_KEY')
+            return api_key
 
         query_arguments = curdoc().session_context.request.arguments
 
@@ -118,10 +122,6 @@ class CurrentUser:
             api_key = api_keys[0]
         else:
             api_key = ""
-
-        # in the development environment, allow overriding the api_key and user_key via env variables
-        if Environment.get_environment() == 'dev':
-            api_key = os.getenv('API_KEY', api_key)
 
         return api_key
 
@@ -133,6 +133,11 @@ class CurrentUser:
             the user_key of the current user
         """
 
+        # in the development environment, allow overriding the api_key and user_key via env variables
+        if Environment.get_environment() == 'dev':
+            user_key = os.getenv('USER_KEY')
+            return user_key
+
         query_arguments = curdoc().session_context.request.arguments
 
         # get the api_key from the request header
@@ -141,10 +146,6 @@ class CurrentUser:
             user_key = user_keys[0]
         else:
             user_key = ""
-
-        # in the development environment, allow overriding the api_key and user_key via env variables
-        if Environment.get_environment() == 'dev':
-            user_key = os.getenv('USER_KEY', user_key)
 
         # convert bytes to str (this comes to fix a problem that the user_key may come as type bytes from the header)
         try:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="mz_bokeh_package",
-    version="0.9.1",
+    version="0.10.0",
     packages=["mz_bokeh_package"],
     include_package_data=True,
 


### PR DESCRIPTION
Hey @roiweinreb ,
could you please have a look at this PR. I essentially have two functions in `CurrentUser` terminate before calling `curdoc()` if the app/package is running in a `dev` environment. That allows for using e.g. the database package in the basic-aiml-package from a script without having to start a bokeh server and clicking through all the options, and makes development much easier...

I'm not so sure what used to be the logic in the previous way of querying first `curdoc()` and then checking for the `dev` environment. In the changes I made, I also removed the default value for two keys in the `os.environ` calls. 

I have the feeling these changes don't affect the behaviour on the platform, but I wouldn't know how to prove it other than running it on the platform, and if it produced a problem it should be visible immediately, right?