### PR TITLE
MZC-1114-Plot-outline-isn't-as-bold-as-the-axes-when-loading-the-dash…

### DIFF
--- a/mz_bokeh_package/components/plot_settings.py
+++ b/mz_bokeh_package/components/plot_settings.py
@@ -88,7 +88,7 @@ POINT_SHAPES = [
     "y",
 ]
 PLOT_DIMENSIONS_SETTINGS = ["custom_plot_dimensions", "plot_height", "plot_width"]
-BASE_SETTINGS = ["grid_lines", "plot_outline", "axes_thickness", *PLOT_DIMENSIONS_SETTINGS]
+BASE_SETTINGS = ["grid_lines", "axes_thickness", "plot_outline", *PLOT_DIMENSIONS_SETTINGS]
 
 
 def get_options_from_ids(ids: List[str]) -> List[Tuple[str]]:


### PR DESCRIPTION
Hey @roiweinreb , @ElanaRB ,

The fix is a one-liner in which the `axes_thickness` needs to be defined before `plot_outline`.
This is needed for the `plot_outline.setter` to know if `axes_thickness` is True or False for it to set it accordingly.