### PR TITLE
use pathlib.Path instead of raw string for path

### DIFF
--- a/mz_bokeh_package/components/plot_settings.py
+++ b/mz_bokeh_package/components/plot_settings.py
@@ -2,6 +2,7 @@
 allows modifying various properties of the plot.
 """
 import os
+from pathlib import Path
 import re
 import itertools
 import numpy as np
@@ -191,7 +192,7 @@ class PlotSettings:
         # Add the settings tool to the plot
         self._settings_plot_tool = CustomAction(
             description=self._plot_tool_description,
-            icon=os.path.join(BASE_DIR, "../assets/img/settings-icon.png"),
+            icon=Path(BASE_DIR, "../assets/img/settings-icon.png"),
             callback=self._get_settings_button_click_js_callback(),
         )
         self._plot.add_tools(self._settings_plot_tool)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="mz_bokeh_package",
-    version="0.12.0",
+    version="0.12.1",
     packages=["mz_bokeh_package"],
     include_package_data=True,
 


### PR DESCRIPTION
@ofir-frd, can you review this small PR? After I merge it and add the v0.12.1 tag, I'll upgrade the version of the mz-bokeh-package in the data-overview-apps to this to get rid of the deprecation warning that appears when the dashboards just start loading. 

This PR includes: 
- A small fix to remove a deprecation warning about changing raw string paths to pahtlib.Path in the latest version of Bokeh. 