### PR TITLE
MZC 1315 related update

### DIFF
--- a/mz_bokeh_package/components/plot_settings.py
+++ b/mz_bokeh_package/components/plot_settings.py
@@ -374,7 +374,7 @@ class PlotSettings:
     @_point_color.setter
     def _point_color(self, value: str):
         for renderer in self._plot.renderers:
-            self._set_color_for_renderer(renderer, value)
+            self._set_color_for_renderer(value, )
 
     @property
     def _text_thickness(self) -> bool:
@@ -708,7 +708,8 @@ class PlotSettings:
             self._set_setting_property(setting_id, value)
             self._set_setting_widget_value(setting_id, value)
 
-    def _set_color_for_renderer(self, renderer: GlyphRenderer, new_color: str):
+    @staticmethod
+    def _set_color_for_renderer(renderer: GlyphRenderer, new_color: str):
         """Set line color and fill color of a bokeh renderer for its default representation,
         as well as for the selection and nonselection glyphs.
 

--- a/mz_bokeh_package/components/plot_settings.py
+++ b/mz_bokeh_package/components/plot_settings.py
@@ -351,8 +351,10 @@ class PlotSettings:
 
             kwargs["fill_alpha"] = fill_alpha
 
-            # Setting a color to initiate the selection_glyph and nonselection_glyph.
-            # The color must be set here and will be overwritten later.
+            # Bokeh-problem: color attributes of the selection_glyph and nonselection_glyph are not synced with
+            # the main glyph.
+            # Solution-workaround: initiate an arbitrary color to the two glyphs. The color will be overwritten
+            # in the _point_color function.
             # See Jira card MZC-1315.
             kwargs["selection_color"] = COLORS_PALETTE[COLORS_NAMES.index("Light Turquoise")]
             kwargs["nonselection_color"] = COLORS_PALETTE[COLORS_NAMES.index("Light Turquoise")]

--- a/mz_bokeh_package/components/plot_settings.py
+++ b/mz_bokeh_package/components/plot_settings.py
@@ -374,7 +374,7 @@ class PlotSettings:
     @_point_color.setter
     def _point_color(self, value: str):
         for renderer in self._plot.renderers:
-            self._set_color_for_renderer(value, )
+            self._set_color_for_renderer(renderer, value)
 
     @property
     def _text_thickness(self) -> bool:

--- a/mz_bokeh_package/components/plot_settings.py
+++ b/mz_bokeh_package/components/plot_settings.py
@@ -351,6 +351,12 @@ class PlotSettings:
 
             kwargs["fill_alpha"] = fill_alpha
 
+            # Setting a color to initiate the selection_glyph and nonselection_glyph.
+            # The color must be set here and will be overwritten later.
+            # See Jira card MZC-1315.
+            kwargs["selection_color"] = COLORS_PALETTE[COLORS_NAMES.index("Light Turquoise")]
+            kwargs["nonselection_color"] = COLORS_PALETTE[COLORS_NAMES.index("Light Turquoise")]
+
             # Create the glyph renderer
             create_glyph(**kwargs)
 
@@ -369,8 +375,9 @@ class PlotSettings:
     @_point_color.setter
     def _point_color(self, value: str):
         for renderer in self._plot.renderers:
-            renderer.glyph.line_color = value
-            renderer.glyph.fill_color = value
+            if renderer.name is None:
+                renderer.name = "arbitery_name"
+            self._set_color_for_renderer(renderer.name, value)
 
     @property
     def _text_thickness(self) -> bool:
@@ -703,6 +710,24 @@ class PlotSettings:
         for setting_id, value in self._plot_settings_state.items():
             self._set_setting_property(setting_id, value)
             self._set_setting_widget_value(setting_id, value)
+
+    def _set_color_for_renderer(self, renderer_name, new_color):
+        """Set line color and fill color to a renderer default presentaion, on selction,
+        and not selected plyphs.
+
+        See Jira card MZC-1315.
+
+        Args:
+            renderer_name: name of the renderer to apply the function.
+            new_color: HEX value of the target color
+        """
+        renderer = self._plot.select(name=renderer_name)
+        renderer.glyph.line_color = new_color
+        renderer.glyph.fill_color = new_color
+        renderer.selection_glyph.line_color = new_color
+        renderer.selection_glyph.fill_color = new_color
+        renderer.nonselection_glyph.line_color = new_color
+        renderer.nonselection_glyph.fill_color = new_color
 
     @staticmethod
     def _find_darker_shade(color: str) -> str:

--- a/mz_bokeh_package/components/plot_settings.py
+++ b/mz_bokeh_package/components/plot_settings.py
@@ -718,10 +718,12 @@ class PlotSettings:
             new_color: HEX value of the target color
         """
 
-        if not renderer.selection_glyph or not renderer.nonselection_glyph:
-            return
         renderer.glyph.line_color = new_color
         renderer.glyph.fill_color = new_color
+
+        if renderer.selection_glyph == "auto" or renderer.nonselection_glyph == "auto":
+            return
+
         renderer.selection_glyph.line_color = new_color
         renderer.selection_glyph.fill_color = new_color
         renderer.nonselection_glyph.line_color = new_color

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="mz_bokeh_package",
-    version="0.12.2",
+    version="0.12.3",
     packages=["mz_bokeh_package"],
     include_package_data=True,
 


### PR DESCRIPTION
This PR is required for [Mzc 1315 staging correlations app points color on the plot changes spontaneously](https://github.com/materialscloud/data-overview-apps/pull/210) in the `data-overview-apps` repo.


### Bokeh-problem:
Color attributes of the selection_glyph and nonselection_glyph are not synced with the main glyph.

### Solution-workaround:
Initiate an arbitrary color to the two glyphs. The color will be overwritten in the _point_color function.

Changes in the PlotSetting:
 - `_point_shape` : An arbitrary color (light Turquoise) is set  the  "selected_color" and "nonselected_color" properties of the kwards. 
 - `_set_color_for_renderer`: A new function that sets colors to glyph , selection_glyph and nonselection_glyph.
 - `_point_color`: now calls `_set_color_for_renderer `to apply color changes.

