### PR TITLE
Setup.py: Allow bokeh 2.4 and 2.3, fix requests to ~=2.28

### DIFF
--- a/mz_bokeh_package/components/confirmation_modal.py
+++ b/mz_bokeh_package/components/confirmation_modal.py
@@ -24,7 +24,7 @@ class ConfirmationModal:
                 to the "preamble" block.
             - Include modal's html: Add the line '{{ confirmation_modal.include_html(confirmation_modal_title, confirmation_modal_widgets) }}'
                 to the "contents" block.
-                
+
         AppState Events Raised:
             confirmation_modal_applied: When the "apply" button is clicked.
             confirmation_modal_canceled: When the "cancel" button is clicked.

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@ from setuptools import setup
 
 setup(
     name="mz_bokeh_package",
-    version="0.13.0",
+    version="0.13.1",
     packages=["mz_bokeh_package"],
     include_package_data=True,
 
     # Requirements for the package.
     install_requires=[
-        "requests",
-        "bokeh~=2.3.0",
+        "requests~=2.28.0",
+        "bokeh>=2.3.0, <2.5",
         "seaborn~=0.12.0",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="mz_bokeh_package",
-    version="0.13.1",
+    version="0.14.1",
     packages=["mz_bokeh_package"],
     include_package_data=True,
 


### PR DESCRIPTION
Hey Ori,

I updated the requirements for the packages. It now allows 2.3 and 2.4 of bokeh. Apparently, the comma in the requirements is interpreted as `AND`, so `bokeh ~=2.3.0, ~-2.4.0` is never fulfilled, and I choose to use >= and < and made sure that the file is processed by pip.

I also fixed the requests package to `~=2.28.0`
Data-Overview-Apps, and Analysis Apps use that package, and it seems to work also on the Ingester.

I already increased the patch number to 0.13.1.