### PR TITLE
MZC-1441 remove path flag when setting cookie and add SameSite and Secure flags

### DIFF
--- a/mz_bokeh_package/components/app_state.py
+++ b/mz_bokeh_package/components/app_state.py
@@ -139,11 +139,11 @@ class AppState:
 
         if env == "dev":
             code = f"""
-            document.cookie = '{user_id}_{dashboard_title}_{cookie_name}={cookie_value}'
+            document.cookie = '{user_id}_{dashboard_title}_{cookie_name}={cookie_value};SameSite=None;Secure'
             """
         else:
             code = f"""
-            document.cookie = '{user_id}_{dashboard_title}_{cookie_name}={cookie_value};domain=.materials.zone;path=/basic-aiml-package/{dashboard_title}'
+            document.cookie = '{user_id}_{dashboard_title}_{cookie_name}={cookie_value};Domain=.materials.zone;SameSite=None;Secure'
             """  # noqa: E501
 
         cookie_saver.js_property_callbacks["change:active"][0].code = code

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="mz_bokeh_package",
-    version="0.14.1",
+    version="0.14.2",
     packages=["mz_bokeh_package"],
     include_package_data=True,
 


### PR DESCRIPTION
@roiweinreb can you please review this PR? It's tiny..

There was a bug that the persistent AppState variables (in particular, the plot settings) were not saved anymore in the cookies. The problem was that you now need to set the flags `SameSite=None` and `Secure` when setting the cookie in an iframe (in the newer browsers).

Furthermore, there was another problem that the path `basic-aiml-package/{dashboard_name}` was hard-coded when setting the cookies. There were two issues caused by this: 

1. We recently renamed the project to `data-overview-apps`.
2. The persistent variables can't be used in other projects. 

To solve this, I removed the `Path` flag. This seems to be OK since: 
1. The dashboard name is encoded in the cookie name, so we don't need it in the path.
2. When you leave the `Path` flag empty, then by default it's set to the project name (which in this case is `/data-overview-apps`).

I tested this both locally (by using the `flask-mz-demo-app` to test what happens with an iframe) and on staging (by deploying the branch to the staging environment).