### PR TITLE
MZC-1441 Add expires option to cookie

### DIFF
--- a/mz_bokeh_package/components/app_state.py
+++ b/mz_bokeh_package/components/app_state.py
@@ -138,13 +138,12 @@ class AppState:
         cookie_saver = curdoc().select_one({"name": "cookie_saver"})
 
         if env == "dev":
-            code = f"""
-            document.cookie = '{user_id}_{dashboard_title}_{cookie_name}={cookie_value};SameSite=None;Secure'
-            """
+            domain_option = ""
         else:
-            code = f"""
-            document.cookie = '{user_id}_{dashboard_title}_{cookie_name}={cookie_value};Domain=.materials.zone;SameSite=None;Secure'
-            """  # noqa: E501
+            domain_option = "Domain=.materials.zone;"
+
+        code = f"document.cookie = '{user_id}_{dashboard_title}_{cookie_name}={cookie_value};" \
+               f"{domain_option}SameSite=None;Secure;Expires=Fri, 31 Dec 9999 23:59:59 GMT'"
 
         cookie_saver.js_property_callbacks["change:active"][0].code = code
         cookie_saver.active = not cookie_saver.active

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="mz_bokeh_package",
-    version="0.14.2",
+    version="0.14.3",
     packages=["mz_bokeh_package"],
     include_package_data=True,
 


### PR DESCRIPTION
@roiweinreb another small update. This PR contains:
- Add "Expires" option to cookie creation, since by default its set to "session" (it actually worked between sessions for users that had their browsers set to "stay where you left", but normally you need to set an "Expires" option for the cookie to remain after you close the tab).