### PR TITLE
Mzc 1543 always use environment variables for urls

### DIFF
--- a/mz_bokeh_package/utilities/environment.py
+++ b/mz_bokeh_package/utilities/environment.py
@@ -28,66 +28,55 @@ class Environment:
     @classmethod
     def get_request_url(cls, endpoint: str) -> str:
         """Converts an endpoint of an API request to a request url. The host should be set in the environment variable
-        'API_HOST'.
+        'API_HOST'. If it is not set, a ValueError will be raised.
 
         Args:
             endpoint: the endpoint of the request
 
         Returns:
             the full URL of the request
-
-        Raises:
-            ValueError: When the environment variable `API_HOST` is not set.
         """
-        host = Environment._get_host_from_env_var('API_HOST')
+        host = Environment._getenv_or_raise_value_error('API_HOST')
         return f"{host}/{endpoint}"
 
     @classmethod
     def get_graphql_api_url(cls) -> str:
         """Returns the url of the GraphQL API Server. The host should be set in the environment variable
-        'GRAPHQL_API_HOST'.
+        'GRAPHQL_API_HOST'. If it is not set, a ValueError will be raised.
 
         Returns:
             the full URL of the GraphQL API server
-
-        Raises:
-            ValueError: When the environment variable `GRAPHQL_API_HOST` is not set.
         """
-        host = Environment._get_host_from_env_var('GRAPHQL_API_HOST')
+        host = Environment._getenv_or_raise_value_error('GRAPHQL_API_HOST')
         return f"{host}"
 
     @classmethod
     def get_parser_service_url(cls, endpoint: str) -> str:
         """Converts an endpoint of the Parser Service to a request url. The host should be set in the environment
-        variable 'PARSER_SERVICE_HOST'.
+        variable 'PARSER_SERVICE_HOST'. If it is not set, a ValueError will be raised.
 
         Args:
             endpoint: the endpoint of the request
 
         Returns:
             the full URL of the request
-
-        Raises:
-            ValueError: When the environment variable `PARSER_SERVICE_HOST` is not set.
         """
 
-        host = Environment._get_host_from_env_var('PARSER_SERVICE_HOST')
+        host = Environment._getenv_or_raise_value_error('PARSER_SERVICE_HOST')
         return f"{host}/{endpoint}"
 
     @classmethod
     def get_webapp_host(cls) -> str:
-        """Get the web app host as set in the environment variable WEBAPP_HOST.
+        """Get the web app host as set in the environment variable WEBAPP_HOST. If it is not set, a ValueError will be
+         raised.
 
         Returns:
             str: Web app host.
-
-        Raises:
-            ValueError: When the environment variable `WEBAPP_HOST` is not set.
         """
-        return Environment._get_host_from_env_var('WEBAPP_HOST')
+        return Environment._getenv_or_raise_value_error('WEBAPP_HOST')
 
     @classmethod
-    def _get_host_from_env_var(cls, env_var_name: str):
+    def _getenv_or_raise_value_error(cls, env_var_name: str):
         host = os.getenv(env_var_name)
         if not host:
             raise ValueError(f'The {env_var_name} environment variable is not set.')

--- a/mz_bokeh_package/utilities/environment.py
+++ b/mz_bokeh_package/utilities/environment.py
@@ -8,13 +8,13 @@ class Environment:
 
     @staticmethod
     def get_environment() -> str:
-        """get the current environment
-
-        Raises:
-            ValueError: Whenever the environment is invalid.
+        """Get the current environment.
 
         Returns:
             str: the current environment, possible values are: 'dev', 'staging' or 'production'
+
+        Raises:
+            ValueError: Whenever the environment is invalid.
         """
 
         # in the kubernetes deployed containers, the environemnt variable ENVIRONMENT is set to staging/production
@@ -27,75 +27,71 @@ class Environment:
 
     @classmethod
     def get_request_url(cls, endpoint: str) -> str:
-        """receives an endpoint of an API request and converts it to a request url based on the environment.
-        If the environment variable 'ENVIRONMENT' is set to 'dev' the environment variable 'API_HOST' should
-        be set to the desired url, including 'https://'. If 'API_HOST' is not set in the development environment,
-        the default staging url will be returned.
+        """Converts an endpoint of an API request to a request url. The host should be set in the environment variable
+        'API_HOST'.
 
         Args:
             endpoint: the endpoint of the request
 
         Returns:
             the full URL of the request
+
+        Raises:
+            ValueError: When the environment variable `API_HOST` is not set.
         """
-
-        env = cls.get_environment()
-
-        if env == 'staging':
-            host = 'https://api-staging.materials.zone/v1beta1'
-        elif env == 'production':
-            host = 'https://api.materials.zone/v1beta1'
-        elif env == 'dev':
-            host = os.getenv('API_HOST', 'https://api-staging.materials.zone/v1beta1')
-
+        host = Environment._get_host_from_env_var('API_HOST')
         return f"{host}/{endpoint}"
 
     @classmethod
     def get_graphql_api_url(cls) -> str:
-        """Returns the url of the GraphQL API Server.
-        If the environment variable 'ENVIRONMENT' is set to 'dev' the environment variable 'GRAPHQL_API_HOST' should
-        be set to the desired url, including 'https://'. If 'GRAPHQL_API_HOST' is not set in the development
-        environment, the default staging url will be returned.
+        """Returns the url of the GraphQL API Server. The host should be set in the environment variable
+        'GRAPHQL_API_HOST'.
 
         Returns:
             the full URL of the GraphQL API server
+
+        Raises:
+            ValueError: When the environment variable `GRAPHQL_API_HOST` is not set.
         """
-
-        env = cls.get_environment()
-
-        if env == 'staging':
-            host = 'https://api-staging.materials.zone/graphql'
-        elif env == 'production':
-            host = 'https://api.materials.zone/graphql'
-        elif env == 'dev':
-            host = os.getenv('GRAPHQL_API_HOST', 'https://api-staging.materials.zone/graphql')
-
+        host = Environment._get_host_from_env_var('GRAPHQL_API_HOST')
         return f"{host}"
 
     @classmethod
     def get_parser_service_url(cls, endpoint: str) -> str:
-        """receives an endpoint of a Parser Service request and converts it to a request url based on the environment.
-        If the environment variable 'ENVIRONMENT' is set to 'dev' the environment variable 'PARSER_SERVICE_HOST' should
-        be set to the desired url, including 'https://'. If 'PARSER_SERVICE_HOST' is not set in the development
-        environment, the default staging url will be returned.
+        """Converts an endpoint of the Parser Service to a request url. The host should be set in the environment
+        variable 'PARSER_SERVICE_HOST'.
 
         Args:
             endpoint: the endpoint of the request
 
         Returns:
             the full URL of the request
+
+        Raises:
+            ValueError: When the environment variable `PARSER_SERVICE_HOST` is not set.
         """
 
-        env = cls.get_environment()
-
-        if env == 'staging':
-            host = 'https://parser-service-staging.materials.zone/api/v1beta1'
-        elif env == 'production':
-            host = 'https://parser-service.materials.zone/api/v1beta1'
-        elif env == 'dev':
-            host = os.getenv('PARSER_SERVICE_HOST', 'https://parser-service-staging.materials.zone/api/v1beta1')
-
+        host = Environment._get_host_from_env_var('PARSER_SERVICE_HOST')
         return f"{host}/{endpoint}"
+
+    @classmethod
+    def get_webapp_host(cls) -> str:
+        """Get the web app host as set in the environment variable WEBAPP_HOST.
+
+        Returns:
+            str: Web app host.
+
+        Raises:
+            ValueError: When the environment variable `WEBAPP_HOST` is not set.
+        """
+        return Environment._get_host_from_env_var('WEBAPP_HOST')
+
+    @classmethod
+    def _get_host_from_env_var(cls, env_var_name: str):
+        host = os.getenv(env_var_name)
+        if not host:
+            raise ValueError(f'The {env_var_name} environment variable is not set.')
+        return host
 
     @classmethod
     def get_error_page_url(cls) -> str:
@@ -111,19 +107,3 @@ class Environment:
             return "https://bokeh-staging.materials.zone/error"
         elif env == 'production':
             return "https://bokeh.materials.zone/error"
-
-    @classmethod
-    def get_webapp_host(cls) -> str:
-        """get the web app host based on the environment.
-
-        Returns:
-            str: Web app host.
-        """
-        env = cls.get_environment()
-
-        if env == "staging":
-            return "https://app-staging.materials.zone"
-        elif env == "production":
-            return "https://app.materials.zone"
-        elif env == "dev":
-            return os.getenv('WEBAPP_HOST', "https://app-staging.materials.zone")

--- a/mz_bokeh_package/utilities/environment.py
+++ b/mz_bokeh_package/utilities/environment.py
@@ -48,7 +48,7 @@ class Environment:
             the full URL of the GraphQL API server
         """
         host = Environment._getenv_or_raise_value_error('GRAPHQL_API_HOST')
-        return f"{host}"
+        return host
 
     @classmethod
     def get_parser_service_url(cls, endpoint: str) -> str:
@@ -79,7 +79,7 @@ class Environment:
     def _getenv_or_raise_value_error(cls, env_var_name: str):
         host = os.getenv(env_var_name)
         if not host:
-            raise ValueError(f'The {env_var_name} environment variable is not set.')
+            raise KeyError(f'The {env_var_name} environment variable is not set.')
         return host
 
     @classmethod

--- a/mz_bokeh_package/utilities/environment.py
+++ b/mz_bokeh_package/utilities/environment.py
@@ -27,8 +27,8 @@ class Environment:
 
     @classmethod
     def get_request_url(cls, endpoint: str) -> str:
-        """Converts an endpoint of an API request to a request url. The host should be set in the environment variable
-        'API_HOST'. If it is not set, a ValueError will be raised.
+        """Converts an endpoint of an External API request to a request url. The host of the External API should be set
+        in the environment variable 'API_HOST'. If it is not set, a KeyError will be raised.
 
         Args:
             endpoint: the endpoint of the request
@@ -41,8 +41,8 @@ class Environment:
 
     @classmethod
     def get_graphql_api_url(cls) -> str:
-        """Returns the url of the GraphQL API Server. The host should be set in the environment variable
-        'GRAPHQL_API_HOST'. If it is not set, a ValueError will be raised.
+        """Returns the url of the GraphQL API Server. The host of the GraphQL API should be set in the environment
+        variable 'GRAPHQL_API_HOST'. If it is not set, a KeyError will be raised.
 
         Returns:
             the full URL of the GraphQL API server
@@ -52,8 +52,8 @@ class Environment:
 
     @classmethod
     def get_parser_service_url(cls, endpoint: str) -> str:
-        """Converts an endpoint of the Parser Service to a request url. The host should be set in the environment
-        variable 'PARSER_SERVICE_HOST'. If it is not set, a ValueError will be raised.
+        """Converts an endpoint of the Parser Service to a request url. The host of the Parser Service should be set in
+        the environment variable 'PARSER_SERVICE_HOST'. If it is not set, a KeyError will be raised.
 
         Args:
             endpoint: the endpoint of the request
@@ -67,7 +67,7 @@ class Environment:
 
     @classmethod
     def get_webapp_host(cls) -> str:
-        """Get the web app host as set in the environment variable WEBAPP_HOST. If it is not set, a ValueError will be
+        """Returns the web app host as set in the environment variable WEBAPP_HOST. If it is not set, a KeyError will be
          raised.
 
         Returns:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="mz_bokeh_package",
-    version="0.14.3",
+    version="0.15.0",
     packages=["mz_bokeh_package"],
     include_package_data=True,
 

--- a/tests/unit/test_environment.py
+++ b/tests/unit/test_environment.py
@@ -31,46 +31,11 @@ test_parameters_get_environment = [
     ("Faulty", "Nothing", ValueError),
 ]
 
-# Parameters for testing GET_REQUEST_URL are:
-# 1.os-environmental variable to be set or None
-# 2. expected reply
-# 3. Optional custom url for dev. environment.
-test_parameters_get_request_url = [
-    ("staging", external_api_url_staging, None),
-    ("production", external_api_url_production, None),
-    ("dev", custom_host_url, custom_host_url[:-1]),
-    ("dev", external_api_url_staging, None),
-    (None, custom_host_url, custom_host_url[:-1]),
-    (None, external_api_url_staging, None),
-]
-
-test_parameters_get_graphql_api_url = [
-    ("staging", graphql_api_url_staging, None),
-    ("production", graphql_api_url_production, None),
-    ("dev", custom_host_url, custom_host_url),
-    ("dev", graphql_api_url_staging, None),
-    (None, custom_host_url, custom_host_url),
-    (None, graphql_api_url_staging, None),
-]
-
 test_parameters_get_error_page_url = [
     ("staging", "https://bokeh-staging.materials.zone/error"),
     ("dev", "https://bokeh-staging.materials.zone/error"),
     (None, "https://bokeh-staging.materials.zone/error"),
     ("production", "https://bokeh.materials.zone/error"),
-]
-
-# Parameters for testing GET_WEBAPP_HOST are:
-# 1.os-environmental variable to be set or None
-# 2. expected reply
-# 3. Optional custom url for dev. environment.
-test_parameters_get_webapp_host = [
-    ("staging", app_url_staging, None),
-    ("production", app_url_production, None),
-    ("dev", custom_host_url[:-1], custom_host_url[:-1]),
-    ("dev", app_url_staging, None),
-    (None, custom_host_url[:-1], custom_host_url[:-1]),
-    (None, app_url_staging, None),
 ]
 
 
@@ -92,29 +57,20 @@ def test_get_environment(environment_set: Optional[str], environment_expected: s
         assert Environment.get_environment() == environment_expected
 
 
-@pytest.mark.parametrize('environment, expected_url, custom_api_host', test_parameters_get_request_url)
-def test_get_request_url(environment: str, expected_url: str, custom_api_host: Optional[str]) -> None:
-    set_environment(environment)
-
+def test_get_request_url():
     if 'API_HOST' in os.environ:
         del os.environ['API_HOST']
-    if custom_api_host is not None:
-        os.environ['API_HOST'] = custom_api_host
+    os.environ['API_HOST'] = "api.host"
 
-    assert Environment.get_request_url("") == expected_url
-    assert Environment.get_request_url("test") == expected_url + "test"
+    assert Environment.get_request_url("endpoint") == "api.host" + "/endpoint"
 
 
-@pytest.mark.parametrize('environment, expected_url, custom_api_host', test_parameters_get_graphql_api_url)
-def test_get_graphql_api_url(environment: str, expected_url: str, custom_api_host: Optional[str]) -> None:
-    set_environment(environment)
-
+def test_get_graphql_api_url():
     if 'GRAPHQL_API_HOST' in os.environ:
         del os.environ['GRAPHQL_API_HOST']
-    if custom_api_host is not None:
-        os.environ['GRAPHQL_API_HOST'] = custom_api_host
+    os.environ['GRAPHQL_API_HOST'] = "graphql.api.host"
 
-    assert Environment.get_graphql_api_url() == expected_url
+    assert Environment.get_graphql_api_url() == "graphql.api.host"
 
 
 @pytest.mark.parametrize('environment_set, expected_url', test_parameters_get_error_page_url)
@@ -124,13 +80,9 @@ def test_get_error_page_url(environment_set: Optional[str], expected_url: str) -
     assert Environment.get_error_page_url() == expected_url
 
 
-@pytest.mark.parametrize('environment, expected_url, custom_api_host', test_parameters_get_webapp_host)
-def test_get_webapp_host(environment: str, expected_url: str, custom_api_host: Optional[str]) -> None:
-    set_environment(environment)
-
+def test_get_webapp_host():
     if 'WEBAPP_HOST' in os.environ:
         del os.environ['WEBAPP_HOST']
-    if custom_api_host is not None:
-        os.environ['WEBAPP_HOST'] = custom_api_host
+    os.environ['WEBAPP_HOST'] = "webapp.host"
 
-    assert Environment.get_webapp_host() == expected_url
+    assert Environment.get_webapp_host() == "webapp.host"


### PR DESCRIPTION
This PR includes changes made in this repo as part of the larger change described [in this card](https://materialszone.atlassian.net/browse/MZC-1490?atlOrigin=eyJpIjoiYzMxMWIzYTQxMWUyNDFlYzllYzUyNTY3YzU4NjdiNWMiLCJwIjoiaiJ9). The changes here are:

1. The `Environment` class exposes 4 methods for getting the URLs of the external API, graphql API, parser service and the web app. Until now, the response of these methods would be environment-dependent. In this PR, I removed the hard-coded environment-dependent addresses of these services and made it mandatory to set the environment variables `API_HOST`, `GRAPHQL_API_HOST`, `PARSER_SERVICE` and `WEBAPP_HOST` in order to fetch these URLs. This means that, when running the apps locally, you always need to set the environment variables that you need (until now it wasn't necessary when working with environment `dev`). I will update the READMEs of the analysis-apps, ingester and data-overview-apps with this change. 

2. The tests for these methods were simplified. 