### PR TITLE
Mzc 1552 custom select collapsible with roi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__
 mz_bokeh_package.egg-info/
 venv
 .vscode
+build
+.python-version

--- a/dashboards/custom_select/main.py
+++ b/dashboards/custom_select/main.py
@@ -7,7 +7,7 @@ options = {"Group 1": [["id1.1", "Title 1.1"], ["id1.2", "Title 1.2"]],
            }
 
 boolean_attributes_ms = ["enabled", "enable_filtering", "include_select_all", "collapsible", "collapsed_by_default"]
-boolean_attributes_single = ["enabled", "enable_filtering", "allow_non_selected"]
+boolean_attributes_single = ["enabled", "enable_filtering", "allow_non_selected", "collapsible", "collapsed_by_default"]
 
 select_widgets = [CustomSelect.create(title="CustomSelect, default settings")]
 multi_select_widgets = [CustomMultiSelect.create(title="CustomMultiSelect, default settings")]
@@ -33,6 +33,10 @@ for attr in boolean_attributes_single:
     non_default_single = not getattr(select_widgets[-1], attr)
     setattr(select_widgets[-1], attr, non_default_single)
     select_widgets[-1].title = f"Select, {attr} {'activated' if non_default_single else 'deactivated'}"
+
+select_widgets.append(CustomSelect.create(title="Select, collapsible AND collapsed_by_default"))
+select_widgets[-1].collapsible = True
+select_widgets[-1].collapsed_by_default = True
 
 for widget in multi_select_widgets + select_widgets:
     widget.options = options

--- a/mz_bokeh_package/custom_widgets/custom_multiselect.py
+++ b/mz_bokeh_package/custom_widgets/custom_multiselect.py
@@ -1,7 +1,6 @@
 """This script defines a custom multiselect widget using a jQuery plugin called "bootstrap-multiselect".
 For more information about the plugin: "http://davidstutz.github.io/bootstrap-multiselect"
 """
-import os
 from bokeh.models import InputWidget
 from bokeh.core.properties import List, Either, String, Tuple, Bool, Int, Nullable, Dict
 from typing import TypeVar, Type
@@ -12,7 +11,7 @@ T = TypeVar("T", bound="CustomMultiSelect")
 class CustomMultiSelect(InputWidget):
     ''' Custom Multi-select widget.
     '''
-    __implementation__ = os.path.join("implementation_files", "multiselect.ts")
+    __implementation__ = "multiselect.ts"
     __javascript__ = [
         "https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js",
         "https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.3/js/bootstrap.bundle.min.js",

--- a/mz_bokeh_package/custom_widgets/custom_multiselect.py
+++ b/mz_bokeh_package/custom_widgets/custom_multiselect.py
@@ -14,13 +14,13 @@ class CustomMultiSelect(InputWidget):
     __implementation__ = "multiselect.ts"
     __javascript__ = [
         "https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js",
-        "https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.3/js/bootstrap.bundle.min.js",
-        "https://cdnjs.cloudflare.com/ajax/libs/bootstrap-multiselect/0.9.16/js/bootstrap-multiselect.min.js",
+        "https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.bundle.min.js",
+        "https://cdnjs.cloudflare.com/ajax/libs/bootstrap-multiselect/1.1.2/js/bootstrap-multiselect.min.js",
         "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.2/js/all.min.js",
     ]
     __css__ = [
-        "https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.3/css/bootstrap.min.css",
-        "https://cdnjs.cloudflare.com/ajax/libs/bootstrap-multiselect/0.9.16/css/bootstrap-multiselect.min.css",
+        "https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/css/bootstrap.min.css",
+        "https://cdnjs.cloudflare.com/ajax/libs/bootstrap-multiselect/1.1.2/css/bootstrap-multiselect.min.css",
     ]
 
     options = Either(Dict(String, List(Either(String, Tuple(String, String)))), List(Either(String, Tuple(String, String))), help="""

--- a/mz_bokeh_package/custom_widgets/custom_select.py
+++ b/mz_bokeh_package/custom_widgets/custom_select.py
@@ -14,13 +14,13 @@ class CustomSelect(InputWidget):
     __implementation__ = "select.ts"
     __javascript__ = [
         "https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js",
-        "https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.3/js/bootstrap.bundle.min.js",
-        "https://cdnjs.cloudflare.com/ajax/libs/bootstrap-multiselect/0.9.16/js/bootstrap-multiselect.min.js",
+        "https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.0/js/bootstrap.bundle.min.js",
+        "https://cdnjs.cloudflare.com/ajax/libs/bootstrap-multiselect/1.1.2/js/bootstrap-multiselect.min.js",
         "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.2/js/all.min.js",
     ]
     __css__ = [
-        "https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.3/css/bootstrap.min.css",
-        "https://cdnjs.cloudflare.com/ajax/libs/bootstrap-multiselect/0.9.16/css/bootstrap-multiselect.min.css",
+        "https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.0/css/bootstrap.min.css",
+        "https://cdnjs.cloudflare.com/ajax/libs/bootstrap-multiselect/1.1.2/css/bootstrap-multiselect.min.css",
     ]
 
     options = Either(Dict(String, List(Either(String, Tuple(String, String)))), List(Either(String, Tuple(String, String))), help="""

--- a/mz_bokeh_package/custom_widgets/custom_select.py
+++ b/mz_bokeh_package/custom_widgets/custom_select.py
@@ -1,7 +1,6 @@
 """This script defines a single select widget using a jQuery plugin called "bootstrap-multiselect".
 For more information about the plugin: "http://davidstutz.github.io/bootstrap-multiselect"
 """
-import os
 from bokeh.models import InputWidget
 from bokeh.core.properties import List, Either, String, Tuple, Bool, Dict
 from typing import TypeVar, Type
@@ -12,7 +11,7 @@ T = TypeVar("T", bound="CustomSelect")
 class CustomSelect(InputWidget):
     ''' Custom select widget.
     '''
-    __implementation__ = os.path.join("implementation_files", "select.ts")
+    __implementation__ = "select.ts"
     __javascript__ = [
         "https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js",
         "https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.3/js/bootstrap.bundle.min.js",

--- a/mz_bokeh_package/custom_widgets/custom_select.py
+++ b/mz_bokeh_package/custom_widgets/custom_select.py
@@ -14,12 +14,12 @@ class CustomSelect(InputWidget):
     __implementation__ = "select.ts"
     __javascript__ = [
         "https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js",
-        "https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.0/js/bootstrap.bundle.min.js",
+        "https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.bundle.min.js",
         "https://cdnjs.cloudflare.com/ajax/libs/bootstrap-multiselect/1.1.2/js/bootstrap-multiselect.min.js",
         "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.2/js/all.min.js",
     ]
     __css__ = [
-        "https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.0/css/bootstrap.min.css",
+        "https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/css/bootstrap.min.css",
         "https://cdnjs.cloudflare.com/ajax/libs/bootstrap-multiselect/1.1.2/css/bootstrap-multiselect.min.css",
     ]
 

--- a/mz_bokeh_package/custom_widgets/custom_select.py
+++ b/mz_bokeh_package/custom_widgets/custom_select.py
@@ -59,6 +59,11 @@ class CustomSelect(InputWidget):
     Indicates whether the widget contains grouped options or not.
     """)
 
+    collapsible = Bool(default=False, help="""Allows to collapse the groups of options.""")
+
+    collapsed_by_default = Bool(default=False, help="""Defines the state of the collapsible groups at startup.
+    Can be set to True only if collapsible is activated.""")
+
     @classmethod
     def create(cls: Type[T], title: str) -> T:
         """This function creates a custom single select filter with the title given.

--- a/mz_bokeh_package/custom_widgets/multiselect.ts
+++ b/mz_bokeh_package/custom_widgets/multiselect.ts
@@ -4,107 +4,10 @@ import * as p from "core/properties"
 
 import {InputWidget, InputWidgetView} from "models/widgets/input_widget"
 
+import {common_styles} from "./select_widgets_common_components"
+
 declare function $(...args: any[]): any
 
-// styles that are common to both single and multi select widgets
-const common_styles = `
-  .dropdown-toggle.custom-select {
-    font-size: inherit;
-    display: flex;
-    background: #fff url('data:image/svg+xml;utf8,<svg version="1.1" viewBox="0 0 25 20" xmlns="http://www.w3.org/2000/svg"><path d="M 0,0 25,0 12.5,20 Z" fill="black" /></svg>') no-repeat right 7px center/7px 10px;
-  }
-  .multiselect-container.dropdown-menu {
-    width: inherit;
-    overflow: auto auto !important;
-  }
-  .multiselect-option.dropdown-item {
-    color: inherit;
-    padding: 0 24px;
-  }
-  .multiselect-option.dropdown-item.active,
-  .multiselect-option.dropdown-item:active {
-    color: inherit;
-    background-color: #FFFFFF;
-  }
-  .multiselect-option.dropdown-item:focus {
-    outline: none;
-  }
-  .multiselect-group.dropdown-item-text {
-    font-size: 13px;
-  }
-  .form-check-input {
-    display: none;
-  }
-  .form-check-label {
-    font-size: 13px;
-  }
-  .dropdown-item.active label.form-check-label::before {
-    background-color: #60cbe0;
-    border: 1px solid #60cbe0;
-  }
-  .dropdown-item.active label.form-check-label::after {
-    display: block;
-  }
-  label.form-check-label::before {
-    content: "";
-    width: 14px;
-    height: 14px;
-    display: block;
-    border: 1px solid currentColor;
-    border-radius: 2px;
-    box-sizing: border-box;
-    left: -21px;
-    top: calc(50% - 7px);
-    position: absolute;
-  }
-  label.form-check-label {
-    position: relative;
-  }
-  label.form-check-label::after {
-    content: "";
-    width: 5px;
-    height: 8px;
-    box-sizing: border-box;
-    border-bottom: 2px solid white;
-    border-right: 2px solid white;
-    position: absolute;
-    display: none;
-    transform: rotate(45deg);
-    left: -16px;
-    top: calc(50% - 5px);
-    z-index: 1;
-  }
-  div.input-group-prepend > svg.input-group-text {
-    width: 30px !important;
-    height: inherit !important;
-  }
-  .multiselect-filter {
-    position: sticky; 
-    top: -6px; 
-    left: 0;
-    right: 0;
-    z-index: 2;
-  }
-  .multiselect-filter .input-group-prepend,
-  .multiselect-filter .input-group-append {
-    height: 31px;
-  }
-  span.multiselect-selected-text {
-    width: 100%; 
-    overflow: hidden; 
-    text-overflow: ellipsis;
-    text-align: left;
-  }
-  span.multiselect-native-select {
-    width: inherit;
-  }
-  .dropdown-item.active:hover {
-    background-color: #f8f9fa;
-  }
-  .multiselect-clear-filter.input-group-text {
-    outline: none;
-  }
-  `
 const default_styles = common_styles + `
   .multiselect-group.dropdown-item,
   .multiselect-all.dropdown-item {

--- a/mz_bokeh_package/custom_widgets/multiselect.ts
+++ b/mz_bokeh_package/custom_widgets/multiselect.ts
@@ -4,7 +4,7 @@ import * as p from "core/properties"
 
 import {InputWidget, InputWidgetView} from "models/widgets/input_widget"
 
-import {common_styles} from "./select_widgets_common_components"
+import {common_styles, DropdownOption, GroupedOptions} from "./select_widgets_common_components"
 
 declare function $(...args: any[]): any
 
@@ -31,16 +31,6 @@ const default_styles = common_styles + `
     background-color: #f8f9fa;
   }
 `;
-
-interface DropdownOption {
-  value: string,
-  label: string,
-  selected: boolean,
-}
-interface GroupedOptions {
-  label: string,
-  children: Array<DropdownOption>
-}
 
 export class CustomMultiSelectView extends InputWidgetView {
   model: CustomMultiSelect

--- a/mz_bokeh_package/custom_widgets/select.ts
+++ b/mz_bokeh_package/custom_widgets/select.ts
@@ -4,7 +4,7 @@ import * as p from "core/properties"
 
 import {InputWidget, InputWidgetView} from "models/widgets/input_widget"
 
-import {common_styles} from "./select_widgets_common_components"
+import {common_styles, DropdownOption, GroupedOptions} from "./select_widgets_common_components"
 
 declare function $(...args: any[]): any
 
@@ -16,16 +16,6 @@ const default_styles = common_styles + `
     border-radius: 50%;
   }
 `;
-
-interface DropdownOption {
-  value: string,
-  label: string,
-  selected: boolean,
-}
-interface GroupedOptions {
-  label: string,
-  children: Array<DropdownOption>
-}
 
 export class CustomSelectView extends InputWidgetView {
   model: CustomSelect
@@ -203,7 +193,7 @@ export class CustomSelectView extends InputWidgetView {
   on_dropdown_change(): void {
     if (this.model.allow_non_selected)
       return
-    
+
     const selected = $('button.multiselect-option.dropdown-item.active', this.group_el)
     
     if (!selected.length) {

--- a/mz_bokeh_package/custom_widgets/select.ts
+++ b/mz_bokeh_package/custom_widgets/select.ts
@@ -117,10 +117,16 @@ export class CustomSelectView extends InputWidgetView {
       onChange: this.on_dropdown_change.bind(this),
       onDropdownShown: this.on_dropdown_opened.bind(this),
       onDropdownHidden: this.on_dropdown_closed.bind(this),
+      enableCollapsibleOptGroups: this.model.collapsible,
+      collapseOptGroupsByDefault: this.model.collapsed_by_default,
     }
 
     if (this.model.width) {
       plugin_config.buttonWidth = `${this.model.width}px`
+    }
+
+    if (!this.model.collapsible) {
+      plugin_config.collapseOptGroupsByDefault = false
     }
 
     return plugin_config
@@ -245,6 +251,8 @@ export namespace CustomSelect {
     allow_non_selected: p.Property<boolean>
     non_selected_text: p.Property<string>
     is_opt_grouped: p.Property<boolean>
+    collapsible: p.Property<boolean>
+    collapsed_by_default: p.Property<boolean>
   }
 }
 
@@ -269,6 +277,8 @@ export class CustomSelect extends InputWidget {
       allow_non_selected:    [ Boolean, true ],
       non_selected_text:     [ String, "Select..." ],
       is_opt_grouped:        [ Boolean, false ],
+      collapsible:           [ Boolean, false ],
+      collapsed_by_default:  [ Boolean, false ],
     }))
   }
 }

--- a/mz_bokeh_package/custom_widgets/select.ts
+++ b/mz_bokeh_package/custom_widgets/select.ts
@@ -4,107 +4,10 @@ import * as p from "core/properties"
 
 import {InputWidget, InputWidgetView} from "models/widgets/input_widget"
 
+import {common_styles} from "./select_widgets_common_components"
+
 declare function $(...args: any[]): any
 
-// styles that are common to both single and multi select widgets
-const common_styles = `
-  .dropdown-toggle.custom-select {
-    font-size: inherit;
-    display: flex;
-    background: #fff url('data:image/svg+xml;utf8,<svg version="1.1" viewBox="0 0 25 20" xmlns="http://www.w3.org/2000/svg"><path d="M 0,0 25,0 12.5,20 Z" fill="black" /></svg>') no-repeat right 7px center/7px 10px;
-  }
-  .multiselect-container.dropdown-menu {
-    width: inherit;
-    overflow: auto auto !important;
-  }
-  .multiselect-option.dropdown-item {
-    color: inherit;
-    padding: 0 24px;
-  }
-  .multiselect-option.dropdown-item.active,
-  .multiselect-option.dropdown-item:active {
-    color: inherit;
-    background-color: #FFFFFF;
-  }
-  .multiselect-option.dropdown-item:focus {
-    outline: none;
-  }
-  .multiselect-group.dropdown-item-text {
-    font-size: 13px;
-  }
-  .form-check-input {
-    display: none;
-  }
-  .form-check-label {
-    font-size: 13px;
-  }
-  .dropdown-item.active label.form-check-label::before {
-    background-color: #60cbe0;
-    border: 1px solid #60cbe0;
-  }
-  .dropdown-item.active label.form-check-label::after {
-    display: block;
-  }
-  label.form-check-label::before {
-    content: "";
-    width: 14px;
-    height: 14px;
-    display: block;
-    border: 1px solid currentColor;
-    border-radius: 2px;
-    box-sizing: border-box;
-    left: -21px;
-    top: calc(50% - 7px);
-    position: absolute;
-  }
-  label.form-check-label {
-    position: relative;
-  }
-  label.form-check-label::after {
-    content: "";
-    width: 5px;
-    height: 8px;
-    box-sizing: border-box;
-    border-bottom: 2px solid white;
-    border-right: 2px solid white;
-    position: absolute;
-    display: none;
-    transform: rotate(45deg);
-    left: -16px;
-    top: calc(50% - 5px);
-    z-index: 1;
-  }
-  div.input-group-prepend > svg.input-group-text {
-    width: 30px !important;
-    height: inherit !important;
-  }
-  .multiselect-filter {
-    position: sticky; 
-    top: -6px; 
-    left: 0;
-    right: 0;
-    z-index: 2;
-  }
-  .multiselect-filter .input-group-prepend,
-  .multiselect-filter .input-group-append {
-    height: 31px;
-  }
-  span.multiselect-selected-text {
-    width: 100%; 
-    overflow: hidden; 
-    text-overflow: ellipsis;
-    text-align: left;
-  }
-  span.multiselect-native-select {
-    width: inherit;
-  }
-  .dropdown-item.active:hover {
-    background-color: #f8f9fa;
-  }
-  .multiselect-clear-filter.input-group-text {
-    outline: none;
-  }
-`
 const default_styles = common_styles + `
   .multiselect-group.dropdown-item-text {
     padding-left: 10px;

--- a/mz_bokeh_package/custom_widgets/select.ts
+++ b/mz_bokeh_package/custom_widgets/select.ts
@@ -19,7 +19,7 @@ const default_styles = common_styles + `
 
 export class CustomSelectView extends InputWidgetView {
   model: CustomSelect
-  protected input_el: HTMLSelectElement
+  protected select_el: HTMLSelectElement
   protected options: any
   protected plugin_config: any
   protected all_values: Array<string|string[]>
@@ -40,12 +40,12 @@ export class CustomSelectView extends InputWidgetView {
     super.initialize()
     super.render()
 
-    this.input_el = this.init_select_element()
+    this.select_el = this.init_select_element()
   }
 
   init_select_element(): HTMLSelectElement{
     // Create a "Select" web element
-    const input_el = select({
+    const select_el = select({
       size: this.model.allow_non_selected ? 2 : 1,  // Allows none of the options to be selected
       class: "custom-select",
       name: this.model.name,
@@ -53,9 +53,9 @@ export class CustomSelectView extends InputWidgetView {
     })
 
     // Add the "Select" web element to its container 
-    this.group_el.appendChild(input_el)
+    this.group_el.appendChild(select_el)
 
-    return input_el
+    return select_el
   }
 
   parse_options_list(options: Array<(string | string[])>): Array<DropdownOption> {
@@ -149,7 +149,7 @@ export class CustomSelectView extends InputWidgetView {
 
     this.plugin_config = this.set_plugin_config()
     
-    $(this.input_el).multiselect(this.plugin_config).multiselect('dataprovider', this.options).multiselect('rebuild')
+    $(this.select_el).multiselect(this.plugin_config).multiselect('dataprovider', this.options).multiselect('rebuild')
   
     // fixes the scroll issue on mobile
     $('.multiselect-container.dropdown-menu', this.group_el).unbind('touchstart')
@@ -185,7 +185,7 @@ export class CustomSelectView extends InputWidgetView {
     const hasOptions = (this.model.is_opt_grouped && this.options.some((opt: any) => opt.children.length)) || this.options.length
     
     if (hasOptions) {
-      $(document).ready(() => $(this.input_el).multiselect(`${this.model.enabled ? 'enable' : 'disable'}`))
+      $(document).ready(() => $(this.select_el).multiselect(`${this.model.enabled ? 'enable' : 'disable'}`))
     }
   }
 
@@ -197,7 +197,7 @@ export class CustomSelectView extends InputWidgetView {
     const selected = $('button.multiselect-option.dropdown-item.active', this.group_el)
     
     if (!selected.length) {
-      $(this.input_el).multiselect('select', this.model.value).multiselect('refresh')
+      $(this.select_el).multiselect('select', this.model.value).multiselect('refresh')
     }
   }
 
@@ -217,7 +217,7 @@ export class CustomSelectView extends InputWidgetView {
   on_dropdown_closed(): void {
     let value: string | string[]
     let was_value_changed: boolean
-    const selectedValue = $(this.input_el).val() || ""
+    const selectedValue = $(this.select_el).val() || ""
 
     if (this.model.is_opt_grouped) {
       value = this.all_values.find((v: any) => v[1] === selectedValue) || ""

--- a/mz_bokeh_package/custom_widgets/select_widgets_common_components.ts
+++ b/mz_bokeh_package/custom_widgets/select_widgets_common_components.ts
@@ -1,0 +1,99 @@
+// styles that are common to both single and multi select widgets
+export const common_styles = `
+  .dropdown-toggle.custom-select {
+    font-size: inherit;
+    display: flex;
+    background: #fff url('data:image/svg+xml;utf8,<svg version="1.1" viewBox="0 0 25 20" xmlns="http://www.w3.org/2000/svg"><path d="M 0,0 25,0 12.5,20 Z" fill="black" /></svg>') no-repeat right 7px center/7px 10px;
+  }
+  .multiselect-container.dropdown-menu {
+    width: inherit;
+    overflow: auto auto !important;
+  }
+  .multiselect-option.dropdown-item {
+    color: inherit;
+    padding: 0 24px;
+  }
+  .multiselect-option.dropdown-item.active,
+  .multiselect-option.dropdown-item:active {
+    color: inherit;
+    background-color: #FFFFFF;
+  }
+  .multiselect-option.dropdown-item:focus {
+    outline: none;
+  }
+  .multiselect-group.dropdown-item-text {
+    font-size: 13px;
+  }
+  .form-check-input {
+    display: none;
+  }
+  .form-check-label {
+    font-size: 13px;
+  }
+  .dropdown-item.active label.form-check-label::before {
+    background-color: #60cbe0;
+    border: 1px solid #60cbe0;
+  }
+  .dropdown-item.active label.form-check-label::after {
+    display: block;
+  }
+  label.form-check-label::before {
+    content: "";
+    width: 14px;
+    height: 14px;
+    display: block;
+    border: 1px solid currentColor;
+    border-radius: 2px;
+    box-sizing: border-box;
+    left: -21px;
+    top: calc(50% - 7px);
+    position: absolute;
+  }
+  label.form-check-label {
+    position: relative;
+  }
+  label.form-check-label::after {
+    content: "";
+    width: 5px;
+    height: 8px;
+    box-sizing: border-box;
+    border-bottom: 2px solid white;
+    border-right: 2px solid white;
+    position: absolute;
+    display: none;
+    transform: rotate(45deg);
+    left: -16px;
+    top: calc(50% - 5px);
+    z-index: 1;
+  }
+  div.input-group-prepend > svg.input-group-text {
+    width: 30px !important;
+    height: inherit !important;
+  }
+  .multiselect-filter {
+    position: sticky;
+    top: -6px;
+    left: 0;
+    right: 0;
+    z-index: 2;
+  }
+  .multiselect-filter .input-group-prepend,
+  .multiselect-filter .input-group-append {
+    height: 31px;
+  }
+  span.multiselect-selected-text {
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-align: left;
+  }
+  span.multiselect-native-select {
+    width: inherit;
+  }
+  .dropdown-item.active:hover {
+    background-color: #f8f9fa;
+  }
+  .multiselect-clear-filter.input-group-text {
+    outline: none;
+  }
+  `

--- a/mz_bokeh_package/custom_widgets/select_widgets_common_components.ts
+++ b/mz_bokeh_package/custom_widgets/select_widgets_common_components.ts
@@ -97,3 +97,13 @@ export const common_styles = `
     outline: none;
   }
   `
+
+export interface DropdownOption {
+  value: string,
+  label: string,
+  selected: boolean,
+}
+export interface GroupedOptions {
+  label: string,
+  children: Array<DropdownOption>
+}


### PR DESCRIPTION
Hey @oriyudilevich,

this is the PR for the collapsible single select widget.

The first few commits just clean up the two parallel widgets a bit. I moved common declarations into a common file. That's not extremely necessary, and probably one could go even further with that, but as it is I found it already helpful to understand the differences between the widgets without being bothered by the common parts and it had helped me in my (unsuccessful) attempts to unite the two widgets

There are two additional changes that come with this PR on the UI:
- the layout of the dropdowns has changed a bit, but I think that's ok. 
- Select all works for the collapsed widgets!!!

===

I was a bit puzzled because this PR (before the last commit) seemed to rely on two versions of one js-library. But the really puzzling thing about it was that bokeh would load js-libraries even though the widget requesting them wasn't used at all in the dashboard. It was enough that it was imported in one of the init files. That sounds as if it would sooner or later lead to collisions, and we should keep that in mind.

Just after I submitted the PR with a longer and more detailed description of this effect, I found a solution for the problem with the two versions - the `bootstrap-multiselect` works only with `bootstrap` 4, and not with 5. Now both CustomSelect widgets use the same dependencies.