### PR TITLE
Doa 23 select all in custom select widgets

### DIFF
--- a/mz_bokeh_package/custom_widgets/custom_multiselect.py
+++ b/mz_bokeh_package/custom_widgets/custom_multiselect.py
@@ -16,11 +16,11 @@ class CustomMultiSelect(InputWidget):
         "https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js",
         "https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.bundle.min.js",
         "https://cdnjs.cloudflare.com/ajax/libs/bootstrap-multiselect/1.1.2/js/bootstrap-multiselect.min.js",
-        "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.2/js/all.min.js",
     ]
     __css__ = [
         "https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/css/bootstrap.min.css",
         "https://cdnjs.cloudflare.com/ajax/libs/bootstrap-multiselect/1.1.2/css/bootstrap-multiselect.min.css",
+        "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.2/css/all.min.css"
     ]
 
     options = Either(Dict(String, List(Either(String, Tuple(String, String)))), List(Either(String, Tuple(String, String))), help="""

--- a/mz_bokeh_package/custom_widgets/custom_select.py
+++ b/mz_bokeh_package/custom_widgets/custom_select.py
@@ -16,11 +16,11 @@ class CustomSelect(InputWidget):
         "https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js",
         "https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.bundle.min.js",
         "https://cdnjs.cloudflare.com/ajax/libs/bootstrap-multiselect/1.1.2/js/bootstrap-multiselect.min.js",
-        "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.2/js/all.min.js",
     ]
     __css__ = [
         "https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/css/bootstrap.min.css",
         "https://cdnjs.cloudflare.com/ajax/libs/bootstrap-multiselect/1.1.2/css/bootstrap-multiselect.min.css",
+        "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.2/css/all.min.css"
     ]
 
     options = Either(Dict(String, List(Either(String, Tuple(String, String)))), List(Either(String, Tuple(String, String))), help="""

--- a/mz_bokeh_package/custom_widgets/multiselect.ts
+++ b/mz_bokeh_package/custom_widgets/multiselect.ts
@@ -4,7 +4,12 @@ import * as p from "core/properties"
 
 import {InputWidget, InputWidgetView} from "models/widgets/input_widget"
 
-import {common_styles, DropdownOption, GroupedOptions} from "./select_widgets_common_components"
+import {
+  common_styles, 
+  DropdownOption, 
+  GroupedOptions, 
+  fix_collapsed_by_default,
+} from "./select_widgets_common_components"
 
 declare function $(...args: any[]): any
 
@@ -193,6 +198,9 @@ export class CustomMultiSelectView extends InputWidgetView {
     this solves the issue that the dropdown items width doesn't 
     stretch when the dropdown overflows on the x axis */
     this.add_options_wrapper()
+
+    if (this.model.collapsed_by_default && this.model.collapsible)
+      fix_collapsed_by_default(this.group_el)
   }
 
   render(): void {

--- a/mz_bokeh_package/custom_widgets/select.ts
+++ b/mz_bokeh_package/custom_widgets/select.ts
@@ -4,7 +4,12 @@ import * as p from "core/properties"
 
 import {InputWidget, InputWidgetView} from "models/widgets/input_widget"
 
-import {common_styles, DropdownOption, GroupedOptions} from "./select_widgets_common_components"
+import {
+  common_styles, 
+  DropdownOption, 
+  GroupedOptions,
+  fix_collapsed_by_default,
+} from "./select_widgets_common_components"
 
 declare function $(...args: any[]): any
 
@@ -177,6 +182,9 @@ export class CustomSelectView extends InputWidgetView {
       const value = this.all_values[0]
       this.model.setv({value}, {silent: true})
     }
+
+    if (this.model.collapsed_by_default && this.model.collapsible)
+      fix_collapsed_by_default(this.group_el)
   }
 
   render(): void {

--- a/mz_bokeh_package/custom_widgets/select_widgets_common_components.ts
+++ b/mz_bokeh_package/custom_widgets/select_widgets_common_components.ts
@@ -1,7 +1,6 @@
 // styles that are common to both single and multi select widgets
 export const common_styles = `
   .custom_select .dropdown-toggle.caret-container {
-    cursor: auto;
     margin-left: -12px;
     padding: 7px 3px 8px 12px;
   }

--- a/mz_bokeh_package/custom_widgets/select_widgets_common_components.ts
+++ b/mz_bokeh_package/custom_widgets/select_widgets_common_components.ts
@@ -1,5 +1,10 @@
 // styles that are common to both single and multi select widgets
 export const common_styles = `
+  .custom_select .dropdown-toggle.caret-container {
+    cursor: auto;
+    margin-left: -12px;
+    padding: 7px 3px 8px 12px;
+  }
   .dropdown-toggle.custom-select {
     font-size: inherit;
     display: flex;

--- a/mz_bokeh_package/custom_widgets/select_widgets_common_components.ts
+++ b/mz_bokeh_package/custom_widgets/select_widgets_common_components.ts
@@ -1,8 +1,13 @@
 // styles that are common to both single and multi select widgets
 export const common_styles = `
+  /* Expand clickable area of the caret for collapsing groups */
   .custom_select .dropdown-toggle.caret-container {
     margin-left: -12px;
     padding: 7px 3px 8px 12px;
+  }
+  /* fix orientation of the open/close caret */
+  .multiselect-container .multiselect-group.closed .dropdown-toggle::after {
+    transform: none !important;
   }
   .dropdown-toggle.custom-select {
     font-size: inherit;

--- a/mz_bokeh_package/custom_widgets/select_widgets_common_components.ts
+++ b/mz_bokeh_package/custom_widgets/select_widgets_common_components.ts
@@ -5,10 +5,6 @@ export const common_styles = `
     margin-left: -12px;
     padding: 7px 3px 8px 12px;
   }
-  /* fix orientation of the open/close caret */
-  .multiselect-container .multiselect-group.closed .dropdown-toggle::after {
-    transform: none !important;
-  }
   .dropdown-toggle.custom-select {
     font-size: inherit;
     display: flex;
@@ -115,4 +111,12 @@ export interface DropdownOption {
 export interface GroupedOptions {
   label: string,
   children: Array<DropdownOption>
+}
+
+declare function $(...args: any[]): any
+
+// Fixes an issue with the "collapseOptGroupsByDefault" plugin setting
+// where the caret icon indicates that the groups are expanded instead of collapsed.
+export function fix_collapsed_by_default(group_el: HTMLElement): void {
+  $('.multiselect-group', group_el).addClass('closed');
 }

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="mz_bokeh_package",
-    version="0.17.0",
+    version="0.17.1",
     packages=["mz_bokeh_package"],
     include_package_data=True,
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="mz_bokeh_package",
-    version="0.17.1",
+    version="0.17.2",
     packages=["mz_bokeh_package"],
     include_package_data=True,
 


### PR DESCRIPTION
With this commit as compared to the current version used on staging:
- The search icon is visible
- The clear icon in the search field is functional
- The clickable area for the collapse symbol is expanded so that there is no area above, below and left of it that would be interpreted as "Select all of this group".
- The cursor over the caret is a regular mouse pointer as opposed to the hand used for selecting the items.

This doesn't solve the issue with the caret being initialised in the wrong state.