### PR TITLE
Mzc 1635 fix case for preselected option

### DIFF
--- a/dashboards/custom_select/main.py
+++ b/dashboards/custom_select/main.py
@@ -38,6 +38,9 @@ select_widgets.append(CustomSelect.create(title="Select, collapsible AND collaps
 select_widgets[-1].collapsible = True
 select_widgets[-1].collapsed_by_default = True
 
+select_widgets.append(CustomSelect.create(title="Select, default with one option preselected."))
+select_widgets[-1].value = ["Group 1", "id1.1"]
+
 for widget in multi_select_widgets + select_widgets:
     widget.options = options
     widget.on_change("value", on_change)

--- a/mz_bokeh_package/custom_widgets/select.ts
+++ b/mz_bokeh_package/custom_widgets/select.ts
@@ -213,11 +213,10 @@ export class CustomSelectView extends InputWidgetView {
 
   // Runs after a change occurs 
   on_dropdown_change(): void {
-    const selected = $('button.multiselect-option.dropdown-item.active', this.group_el)
-
     if (this.model.allow_non_selected)
-      selected[0].onclick = this.deselect_option.bind(this)
       return
+
+    const selected = $('button.multiselect-option.dropdown-item.active', this.group_el)
     
     if (!selected.length) {
       $(this.select_el).multiselect('select', this.model.value).multiselect('refresh')

--- a/mz_bokeh_package/custom_widgets/select.ts
+++ b/mz_bokeh_package/custom_widgets/select.ts
@@ -183,6 +183,11 @@ export class CustomSelectView extends InputWidgetView {
       this.model.setv({value}, {silent: true})
     }
 
+    // allow for deselecting and leaving the widget in the unselected state.
+    const selected_button = $('button.multiselect-option.dropdown-item.active', this.group_el)
+    if (this.model.allow_non_selected && selected_button.length)
+      selected_button[0].onclick = this.deselect_option.bind(this)
+
     if (this.model.collapsed_by_default && this.model.collapsible)
       fix_collapsed_by_default(this.group_el)
   }

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="mz_bokeh_package",
-    version="0.18.1",
+    version="0.18.2",
     packages=["mz_bokeh_package"],
     include_package_data=True,
 


### PR DESCRIPTION
[MZC-1635](https://materialszone.atlassian.net/browse/MZC-1635)

Hey @roiweinreb  and @ofir-frd ,

Once more... There was an issue with the previous solution that it would not be possible to deselect an option when the value was set from the python side. Therefore, I moved the action of binding the function `deselect_option` to the button to the function `apply_plugin` which is called also when the value is set by python.

I also added a case where you can see that action to the demo dashboard.

[MZC-1635]: https://materialszone.atlassian.net/browse/MZC-1635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ